### PR TITLE
updated Gemfile.lock to use latest version of obvious gem

### DIFF
--- a/delivery/rails_app/Gemfile.lock
+++ b/delivery/rails_app/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
     mime-types (1.19)
     moped (1.3.2)
     multi_json (1.5.0)
-    obvious (0.0.2)
+    obvious (0.0.10)
     polyglot (0.3.3)
     rack (1.4.1)
     rack-cache (1.2)


### PR DESCRIPTION
Another alternative would be to use the twiddle-waka to specify a minimum version.